### PR TITLE
Proj 259 add performance counters to splash 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.o
 *.h
 
-codes/runtest
+codes/splash3
 
 codes/apps/barnes/BARNES
 codes/apps/fmm/FMM

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.c
 *.o
 *.h
+
+codes/runtest
+
 codes/apps/barnes/BARNES
 codes/apps/fmm/FMM
 codes/apps/ocean/contiguous_partitions/OCEAN

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -1,13 +1,55 @@
 .PHONY: all clean
 
-all:
+runtest :
+	echo "cd /perf/splash3/codes/apps/barnes" > runtest
+	echo "./BARNES < inputs/n16384-p2" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/fmm" >> runtest
+	echo "./FMM < inputs/input.2.16384" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/ocean/contiguous_partitions" >> runtest
+	echo "./OCEAN -p2 -n258" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/ocean/non_contiguous_partitions" >> runtest
+	echo "./OCEAN -p2 -n258" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/radiosity" >> runtest
+	echo "./RADIOSITY -p 2 -ae 5000 -bf 0.1 -en 0.05 -room -batch" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/raytrace" >> runtest
+	echo "./RAYTRACE -p2 -m64 inputs/car.env" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/water-nsquared" >> runtest
+	echo "./WATER-NSQUARED < inputs/n512-p2" >> runtest
+
+	echo "cd /perf/splash3/codes/apps/water-spatial" >> runtest
+	echo "./WATER-SPATIAL < inputs/n512-p2" >> runtest
+
+	echo "cd /perf/splash3/codes/kernels/cholesky" >> runtest
+	echo "./CHOLESKY -p2 < inputs/tk15.O" >> runtest
+
+	echo "cd /perf/splash3/codes/kernels/fft" >> runtest
+	echo "./FFT -p2 -m16" >> runtest
+
+	echo "cd /perf/splash3/codes/kernels/lu/contiguous_blocks" >> runtest
+	echo "./LU -p2 -n512" >> runtest
+
+	echo "cd /perf/splash3/codes/kernels/lu/non_contiguous_blocks" >> runtest
+	echo "./LU -p2 -n512" >> runtest
+
+	echo "cd /perf/splash3/codes/kernels/radix" >> runtest
+	echo "./RADIX -p2 -n1048576" >> runtest
+
+	chmod +x runtest
+
+all: runtest
 	$(MAKE) -C apps/barnes
 	$(MAKE) -C apps/fmm
 	$(MAKE) -C apps/ocean/contiguous_partitions
 	$(MAKE) -C apps/ocean/non_contiguous_partitions
 	$(MAKE) -C apps/radiosity
 	$(MAKE) -C apps/raytrace
-	$(MAKE) -C apps/volrend
+        # $(MAKE) -C apps/volrend
 	$(MAKE) -C apps/water-nsquared
 	$(MAKE) -C apps/water-spatial
 	$(MAKE) -C kernels/cholesky
@@ -23,7 +65,7 @@ clean:
 	$(MAKE) -C apps/ocean/non_contiguous_partitions clean
 	$(MAKE) -C apps/radiosity clean
 	$(MAKE) -C apps/raytrace clean
-	$(MAKE) -C apps/volrend clean
+        #$(MAKE) -C apps/volrend clean
 	$(MAKE) -C apps/water-nsquared clean
 	$(MAKE) -C apps/water-spatial clean
 	$(MAKE) -C kernels/cholesky clean

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -43,7 +43,7 @@ runtest :
 	chmod +x $@
 
 XLEN = 64
-CVA_SDK_ROOT = $(abspath ../../culsans/cva6-sdk)
+CVA_SDK_ROOT = $(abspath ../../../cva6-sdk)
 
 all: export TOOLCHAIN_PREFIX = $(CVA_SDK_ROOT)/buildroot/output/host/bin/riscv$(XLEN)-buildroot-linux-gnu-
 all: runtest

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -1,75 +1,80 @@
 .PHONY: all clean
 
 runtest :
-	echo "cd /perf/splash3/codes/apps/barnes" > runtest
-	echo "./BARNES < inputs/n16384-p2" >> runtest
+	echo "cd /perf/splash3/codes/apps/barnes" > $@
+	echo "./BARNES < inputs/n16384-p2" >> $@
 
-	echo "cd /perf/splash3/codes/apps/fmm" >> runtest
-	echo "./FMM < inputs/input.2.16384" >> runtest
+	echo "cd /perf/splash3/codes/apps/fmm" >> $@
+	echo "./FMM < inputs/input.2.16384" >> $@
 
-	echo "cd /perf/splash3/codes/apps/ocean/contiguous_partitions" >> runtest
-	echo "./OCEAN -p2 -n258" >> runtest
+	echo "cd /perf/splash3/codes/apps/ocean/contiguous_partitions" >> $@
+	echo "./OCEAN -p2 -n258" >> $@
 
-	echo "cd /perf/splash3/codes/apps/ocean/non_contiguous_partitions" >> runtest
-	echo "./OCEAN -p2 -n258" >> runtest
+	echo "cd /perf/splash3/codes/apps/ocean/non_contiguous_partitions" >> $@
+	echo "./OCEAN -p2 -n258" >> $@
 
-	echo "cd /perf/splash3/codes/apps/radiosity" >> runtest
-	echo "./RADIOSITY -p 2 -ae 5000 -bf 0.1 -en 0.05 -room -batch" >> runtest
+	echo "cd /perf/splash3/codes/apps/radiosity" >> $@
+	echo "./RADIOSITY -p 2 -ae 5000 -bf 0.1 -en 0.05 -room -batch" >> $@
 
-	echo "cd /perf/splash3/codes/apps/raytrace" >> runtest
-	echo "./RAYTRACE -p2 -m64 inputs/car.env" >> runtest
+	echo "cd /perf/splash3/codes/apps/raytrace" >> $@
+	echo "./RAYTRACE -p2 -m64 inputs/car.env" >> $@
 
-	echo "cd /perf/splash3/codes/apps/water-nsquared" >> runtest
-	echo "./WATER-NSQUARED < inputs/n512-p2" >> runtest
+	echo "cd /perf/splash3/codes/apps/water-nsquared" >> $@
+	echo "./WATER-NSQUARED < inputs/n512-p2" >> $@
 
-	echo "cd /perf/splash3/codes/apps/water-spatial" >> runtest
-	echo "./WATER-SPATIAL < inputs/n512-p2" >> runtest
+	echo "cd /perf/splash3/codes/apps/water-spatial" >> $@
+	echo "./WATER-SPATIAL < inputs/n512-p2" >> $@
 
-	echo "cd /perf/splash3/codes/kernels/cholesky" >> runtest
-	echo "./CHOLESKY -p2 < inputs/tk15.O" >> runtest
+	echo "cd /perf/splash3/codes/kernels/cholesky" >> $@
+	echo "./CHOLESKY -p2 < inputs/tk15.O" >> $@
 
-	echo "cd /perf/splash3/codes/kernels/fft" >> runtest
-	echo "./FFT -p2 -m16" >> runtest
+	echo "cd /perf/splash3/codes/kernels/fft" >> $@
+	echo "./FFT -p2 -m16" >> $@
 
-	echo "cd /perf/splash3/codes/kernels/lu/contiguous_blocks" >> runtest
-	echo "./LU -p2 -n512" >> runtest
+	echo "cd /perf/splash3/codes/kernels/lu/contiguous_blocks" >> $@
+	echo "./LU -p2 -n512" >> $@
 
-	echo "cd /perf/splash3/codes/kernels/lu/non_contiguous_blocks" >> runtest
-	echo "./LU -p2 -n512" >> runtest
+	echo "cd /perf/splash3/codes/kernels/lu/non_contiguous_blocks" >> $@
+	echo "./LU -p2 -n512" >> $@
 
-	echo "cd /perf/splash3/codes/kernels/radix" >> runtest
-	echo "./RADIX -p2 -n1048576" >> runtest
+	echo "cd /perf/splash3/codes/kernels/radix" >> $@
+	echo "./RADIX -p2 -n1048576" >> $@
 
-	chmod +x runtest
+	chmod +x $@
 
+XLEN = 64
+CVA_SDK_ROOT = $(abspath ../../culsans/cva6-sdk)
+
+all: export TOOLCHAIN_PREFIX = $(CVA_SDK_ROOT)/buildroot/output/host/bin/riscv$(XLEN)-buildroot-linux-gnu-
 all: runtest
-	$(MAKE) -C apps/barnes
-	$(MAKE) -C apps/fmm
-	$(MAKE) -C apps/ocean/contiguous_partitions
-	$(MAKE) -C apps/ocean/non_contiguous_partitions
-	$(MAKE) -C apps/radiosity
-	$(MAKE) -C apps/raytrace
-        # $(MAKE) -C apps/volrend
-	$(MAKE) -C apps/water-nsquared
-	$(MAKE) -C apps/water-spatial
-	$(MAKE) -C kernels/cholesky
-	$(MAKE) -C kernels/fft
-	$(MAKE) -C kernels/lu/contiguous_blocks
-	$(MAKE) -C kernels/lu/non_contiguous_blocks
-	$(MAKE) -C kernels/radix
+	$(MAKE) --no-print-directory -C apps/barnes
+	$(MAKE) --no-print-directory -C apps/fmm
+	$(MAKE) --no-print-directory -C apps/ocean/contiguous_partitions
+	$(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions
+	$(MAKE) --no-print-directory -C apps/radiosity
+	$(MAKE) --no-print-directory -C apps/raytrace
+	# $(MAKE) --no-print-directory -C apps/volrend
+	$(MAKE) --no-print-directory -C apps/water-nsquared
+	$(MAKE) --no-print-directory -C apps/water-spatial
+	$(MAKE) --no-print-directory -C kernels/cholesky
+	$(MAKE) --no-print-directory -C kernels/fft
+	$(MAKE) --no-print-directory -C kernels/lu/contiguous_blocks
+	$(MAKE) --no-print-directory -C kernels/lu/non_contiguous_blocks
+	$(MAKE) --no-print-directory -C kernels/radix
 
 clean:
-	$(MAKE) -C apps/barnes clean
-	$(MAKE) -C apps/fmm clean
-	$(MAKE) -C apps/ocean/contiguous_partitions clean
-	$(MAKE) -C apps/ocean/non_contiguous_partitions clean
-	$(MAKE) -C apps/radiosity clean
-	$(MAKE) -C apps/raytrace clean
-        #$(MAKE) -C apps/volrend clean
-	$(MAKE) -C apps/water-nsquared clean
-	$(MAKE) -C apps/water-spatial clean
-	$(MAKE) -C kernels/cholesky clean
-	$(MAKE) -C kernels/fft clean
-	$(MAKE) -C kernels/lu/contiguous_blocks clean
-	$(MAKE) -C kernels/lu/non_contiguous_blocks clean
-	$(MAKE) -C kernels/radix clean
+	rm -f runtest
+	$(MAKE) --no-print-directory -C apps/barnes clean
+	$(MAKE) --no-print-directory -C apps/fmm clean
+	$(MAKE) --no-print-directory -C apps/ocean/contiguous_partitions clean
+	$(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions clean
+	$(MAKE) --no-print-directory -C apps/radiosity clean
+	$(MAKE) --no-print-directory -C apps/raytrace clean
+	# $(MAKE) --no-print-directory -C apps/volrend clean
+	$(MAKE) --no-print-directory -C apps/water-nsquared clean
+	$(MAKE) --no-print-directory -C apps/water-spatial clean
+	$(MAKE) --no-print-directory -C kernels/cholesky clean
+	$(MAKE) --no-print-directory -C kernels/fft clean
+	$(MAKE) --no-print-directory -C kernels/lu/contiguous_blocks clean
+	$(MAKE) --no-print-directory -C kernels/lu/non_contiguous_blocks clean
+	$(MAKE) --no-print-directory -C kernels/radix clean

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -42,10 +42,6 @@ runtest :
 
 	chmod +x $@
 
-XLEN = 64
-CVA_SDK_ROOT = $(abspath ../../../cva6-sdk)
-
-all: export TOOLCHAIN_PREFIX = $(CVA_SDK_ROOT)/buildroot/output/host/bin/riscv$(XLEN)-buildroot-linux-gnu-
 all: runtest
 	$(MAKE) --no-print-directory -C apps/barnes
 	$(MAKE) --no-print-directory -C apps/fmm

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -87,35 +87,35 @@ splash3/runtest : splash3
 	chmod +x $@
 
 all:
-	$(MAKE) --no-print-directory -C apps/barnes
-	$(MAKE) --no-print-directory -C apps/fmm
-	$(MAKE) --no-print-directory -C apps/ocean/contiguous_partitions
-	# $(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions
-	$(MAKE) --no-print-directory -C apps/radiosity
-	$(MAKE) --no-print-directory -C apps/raytrace
-	# $(MAKE) --no-print-directory -C apps/volrend
-	$(MAKE) --no-print-directory -C apps/water-nsquared
-	$(MAKE) --no-print-directory -C apps/water-spatial
-	$(MAKE) --no-print-directory -C kernels/cholesky
-	$(MAKE) --no-print-directory -C kernels/fft
-	$(MAKE) --no-print-directory -C kernels/lu/contiguous_blocks
-	$(MAKE) --no-print-directory -C kernels/lu/non_contiguous_blocks
-	$(MAKE) --no-print-directory -C kernels/radix
-	$(MAKE) --no-print-directory splash3/runtest
+	$(MAKE) -C apps/barnes
+	$(MAKE) -C apps/fmm
+	$(MAKE) -C apps/ocean/contiguous_partitions
+	# $(MAKE) -C apps/ocean/non_contiguous_partitions
+	$(MAKE) -C apps/radiosity
+	$(MAKE) -C apps/raytrace
+	# $(MAKE) -C apps/volrend
+	$(MAKE) -C apps/water-nsquared
+	$(MAKE) -C apps/water-spatial
+	$(MAKE) -C kernels/cholesky
+	$(MAKE) -C kernels/fft
+	$(MAKE) -C kernels/lu/contiguous_blocks
+	$(MAKE) -C kernels/lu/non_contiguous_blocks
+	$(MAKE) -C kernels/radix
+	$(MAKE)  splash3/runtest
 
 clean:
 	rm -rf splash3
-	$(MAKE) --no-print-directory -C apps/barnes clean
-	$(MAKE) --no-print-directory -C apps/fmm clean
-	$(MAKE) --no-print-directory -C apps/ocean/contiguous_partitions clean
-	# $(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions clean
-	$(MAKE) --no-print-directory -C apps/radiosity clean
-	$(MAKE) --no-print-directory -C apps/raytrace clean
-	# $(MAKE) --no-print-directory -C apps/volrend clean
-	$(MAKE) --no-print-directory -C apps/water-nsquared clean
-	$(MAKE) --no-print-directory -C apps/water-spatial clean
-	$(MAKE) --no-print-directory -C kernels/cholesky clean
-	$(MAKE) --no-print-directory -C kernels/fft clean
-	$(MAKE) --no-print-directory -C kernels/lu/contiguous_blocks clean
-	$(MAKE) --no-print-directory -C kernels/lu/non_contiguous_blocks clean
-	$(MAKE) --no-print-directory -C kernels/radix clean
+	$(MAKE) -C apps/barnes clean
+	$(MAKE) -C apps/fmm clean
+	$(MAKE) -C apps/ocean/contiguous_partitions clean
+	# $(MAKE) -C apps/ocean/non_contiguous_partitions clean
+	$(MAKE) -C apps/radiosity clean
+	$(MAKE) -C apps/raytrace clean
+	# $(MAKE) -C apps/volrend clean
+	$(MAKE) -C apps/water-nsquared clean
+	$(MAKE) -C apps/water-spatial clean
+	$(MAKE) -C kernels/cholesky clean
+	$(MAKE) -C kernels/fft clean
+	$(MAKE) -C kernels/lu/contiguous_blocks clean
+	$(MAKE) -C kernels/lu/non_contiguous_blocks clean
+	$(MAKE) -C kernels/radix clean

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -1,6 +1,53 @@
 .PHONY: all clean
 
-runtest :
+# create a minimal directory to be included in the fpga image
+splash3 :
+	mkdir -p                                       $@/codes/apps/barnes/inputs
+	cp apps/barnes/BARNES                          $@/codes/apps/barnes/
+	cp apps/barnes/inputs/n16384-p2                $@/codes/apps/barnes/inputs/
+
+	mkdir -p                                       $@/codes/apps/fmm/inputs
+	cp apps/fmm/FMM                                $@/codes/apps/fmm/
+	cp apps/fmm/inputs/input.2.16384               $@/codes/apps/fmm/inputs/
+
+	mkdir -p                                       $@/codes/apps/ocean/contiguous_partitions
+	cp apps/ocean/contiguous_partitions/OCEAN      $@/codes/apps/ocean/contiguous_partitions/
+
+	mkdir -p                                       $@/codes/apps/radiosity
+	cp apps/radiosity/RADIOSITY                    $@/codes/apps/radiosity/
+
+	mkdir -p                                       $@/codes/apps/raytrace/inputs
+	cp apps/raytrace/RAYTRACE                      $@/codes/apps/raytrace/
+	cp apps/raytrace/inputs/car.*                  $@/codes/apps/raytrace/inputs/
+
+	mkdir -p                                       $@/codes/apps/water-nsquared/inputs
+	cp apps/water-nsquared/WATER-NSQUARED          $@/codes/apps/water-nsquared/
+	cp apps/water-nsquared/random.in               $@/codes/apps/water-nsquared/
+	cp apps/water-nsquared/inputs/n512-p2          $@/codes/apps/water-nsquared/inputs/
+
+	mkdir -p                                       $@/codes/apps/water-spatial/inputs
+	cp apps/water-spatial/WATER-SPATIAL            $@/codes/apps/water-spatial/
+	cp apps/water-spatial/random.in                $@/codes/apps/water-spatial/
+	cp apps/water-spatial/inputs/n512-p2           $@/codes/apps/water-spatial/inputs/
+
+	mkdir -p                                       $@/codes/kernels/cholesky/inputs
+	cp kernels/cholesky/CHOLESKY                   $@/codes/kernels/cholesky/
+	cp kernels/cholesky/inputs/tk15.O              $@/codes/kernels/cholesky/inputs/
+
+	mkdir -p                                       $@/codes/kernels/fft
+	cp kernels/fft/FFT                             $@/codes/kernels/fft/
+
+	mkdir -p                                       $@/codes/kernels/lu/contiguous_blocks
+	cp kernels/lu/contiguous_blocks/LU             $@/codes/kernels/lu/contiguous_blocks/
+
+	mkdir -p                                       $@/codes/kernels/lu/non_contiguous_blocks
+	cp kernels/lu/non_contiguous_blocks/LU         $@/codes/kernels/lu/non_contiguous_blocks/
+
+	mkdir -p                                       $@/codes/kernels/radix
+	cp kernels/radix/RADIX                         $@/codes/kernels/radix/
+
+
+splash3/runtest : splash3
 	echo "cd /perf/splash3/codes/apps/barnes" > $@
 	echo "./BARNES < inputs/n16384-p2" >> $@
 
@@ -8,9 +55,6 @@ runtest :
 	echo "./FMM < inputs/input.2.16384" >> $@
 
 	echo "cd /perf/splash3/codes/apps/ocean/contiguous_partitions" >> $@
-	echo "./OCEAN -p2 -n258" >> $@
-
-	echo "cd /perf/splash3/codes/apps/ocean/non_contiguous_partitions" >> $@
 	echo "./OCEAN -p2 -n258" >> $@
 
 	echo "cd /perf/splash3/codes/apps/radiosity" >> $@
@@ -42,11 +86,11 @@ runtest :
 
 	chmod +x $@
 
-all: runtest
+all:
 	$(MAKE) --no-print-directory -C apps/barnes
 	$(MAKE) --no-print-directory -C apps/fmm
 	$(MAKE) --no-print-directory -C apps/ocean/contiguous_partitions
-	$(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions
+	# $(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions
 	$(MAKE) --no-print-directory -C apps/radiosity
 	$(MAKE) --no-print-directory -C apps/raytrace
 	# $(MAKE) --no-print-directory -C apps/volrend
@@ -57,13 +101,14 @@ all: runtest
 	$(MAKE) --no-print-directory -C kernels/lu/contiguous_blocks
 	$(MAKE) --no-print-directory -C kernels/lu/non_contiguous_blocks
 	$(MAKE) --no-print-directory -C kernels/radix
+	$(MAKE) --no-print-directory splash3/runtest
 
 clean:
-	rm -f runtest
+	rm -rf splash3
 	$(MAKE) --no-print-directory -C apps/barnes clean
 	$(MAKE) --no-print-directory -C apps/fmm clean
 	$(MAKE) --no-print-directory -C apps/ocean/contiguous_partitions clean
-	$(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions clean
+	# $(MAKE) --no-print-directory -C apps/ocean/non_contiguous_partitions clean
 	$(MAKE) --no-print-directory -C apps/radiosity clean
 	$(MAKE) --no-print-directory -C apps/raytrace clean
 	# $(MAKE) --no-print-directory -C apps/volrend clean

--- a/codes/apps/barnes/code.c.in
+++ b/codes/apps/barnes/code.c.in
@@ -316,11 +316,11 @@ int main (int argc, string argv[])
 
    // read out performance counters
    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
 
    printf("MISS_END        = %12lu\n",miss_cntr_end);
    printf("HIT_END         = %12lu\n",hit_cntr_end);

--- a/codes/apps/barnes/code.c.in
+++ b/codes/apps/barnes/code.c.in
@@ -253,26 +253,41 @@ int main (int argc, string argv[])
    }
 
    // initialize performance counters
-   long unsigned miss_cntr_start,       miss_cntr_end;
-   long unsigned hit_cntr_start,        hit_cntr_end;
-   long unsigned flush_cntr_start,      flush_cntr_end;
-   long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
-   long unsigned amo_cntr_start,        amo_cntr_end;
-   long unsigned cycles_cntr_start,     cycles_cntr_end;
+   long unsigned miss_cntr_start,               miss_cntr_end;
+   long unsigned hit_cntr_start,                hit_cntr_end;
+   long unsigned flush_cntr_start,              flush_cntr_end;
+   long unsigned flush_pulse_cntr_start,        flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,                amo_cntr_end;
+   long unsigned cycles_cntr_start,             cycles_cntr_end;
+   long unsigned wr_hit_unique_cntr_start,      wr_hit_unique_cntr_end;
+   long unsigned wr_hit_shared_cntr_start,      wr_hit_shared_cntr_end;
+   long unsigned wr_miss_cntr_start,            wr_miss_cntr_end;
+   long unsigned clean_invalid_hit_cntr_start,  clean_invalid_hit_cntr_end;
+   long unsigned clean_invalid_miss_cntr_start, clean_invalid_miss_cntr_end;
 
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_start));
 
-   printf("MISS_START        = %12lu\n",miss_cntr_start);
-   printf("HIT_START         = %12lu\n",hit_cntr_start);
-   printf("FLUSH_START       = %12lu\n",flush_cntr_start);
-   printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
-   printf("AMO_START         = %12lu\n",amo_cntr_start);
-   printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+   printf("MISS_START               = %12lu\n",miss_cntr_start);
+   printf("HIT_START                = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START              = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START        = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START                = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START             = %12lu\n",cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE_START   = %12lu\n",wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED_START   = %12lu\n",wr_hit_shared_cntr_start);
+   printf("WRITE_MISS_START         = %12lu\n",wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT_START  = %12lu\n",clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS_START = %12lu\n",clean_invalid_miss_cntr_start);
    printf("\n");
 
    Global = NULL;
@@ -315,27 +330,43 @@ int main (int argc, string argv[])
 	  Global->tracktime);
 
    // read out performance counters
-   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_end));
 
-   printf("MISS_END        = %12lu\n",miss_cntr_end);
-   printf("HIT_END         = %12lu\n",hit_cntr_end);
-   printf("FLUSH_END       = %12lu\n",flush_cntr_end);
-   printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
-   printf("AMO_END         = %12lu\n",amo_cntr_end);
-   printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+   printf("\n");
+   printf("MISS_END                 = %12lu\n",miss_cntr_end);
+   printf("HIT_END                  = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END                = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END          = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END                  = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END               = %12lu\n",cycles_cntr_end);
+   printf("WRITE_HIT_UNIQUE_END     = %12lu\n",wr_hit_unique_cntr_end);
+   printf("WRITE_HIT_SHARED_END     = %12lu\n",wr_hit_shared_cntr_end);
+   printf("WRITE_MISS_END           = %12lu\n",wr_miss_cntr_end);
+   printf("CLEAN_INVALID_HIT_END    = %12lu\n",clean_invalid_hit_cntr_end);
+   printf("CLEAN_INVALID_MISS_END   = %12lu\n",clean_invalid_miss_cntr_end);
    printf("\n");
 
-   printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
-   printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
-   printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
-   printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
-   printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
-   printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("MISS COUNT               = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT                = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT              = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT        = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT                = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT             = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE COUNT   = %12lu\n",wr_hit_unique_cntr_end - wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED COUNT   = %12lu\n",wr_hit_shared_cntr_end - wr_hit_shared_cntr_start);
+   printf("WRITE_MISS COUNT         = %12lu\n",wr_miss_cntr_end - wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT COUNT  = %12lu\n",clean_invalid_hit_cntr_end - clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS COUNT = %12lu\n",clean_invalid_miss_cntr_end - clean_invalid_miss_cntr_start);
    printf("\n");
 
    MAIN_END;

--- a/codes/apps/barnes/code.c.in
+++ b/codes/apps/barnes/code.c.in
@@ -252,6 +252,21 @@ int main (int argc, string argv[])
      }
    }
 
+   long unsigned cntr3,cntr4,cntr5,cntr6,cntr7,cntr8;
+
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(cntr3));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(cntr4));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(cntr5));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(cntr6));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(cntr7));
+   printf("MISS_START        = %12lu\n",cntr3);
+   printf("HIT_START         = %12lu\n",cntr4);
+   printf("FLUSH_START       = %12lu\n",cntr5);
+   printf("FLUSH_PULSE_START = %12lu\n",cntr6);
+   printf("AMO_START         = %12lu\n",cntr7);
+   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cntr8));
+   printf("CYCLES_START      = %12lu\n",cntr8);
+
    Global = NULL;
    initparam(defv);
    startrun();
@@ -274,6 +289,7 @@ int main (int argc, string argv[])
    SPLASH3_ROI_END();
 
    CLOCK(Global->computeend);
+   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cntr8));
 
    printf("COMPUTEEND    = %12lu\n",Global->computeend);
    printf("COMPUTETIME   = %12lu\n",Global->computeend - Global->computestart);
@@ -290,6 +306,19 @@ int main (int argc, string argv[])
 	  ((float)(Global->tracktime-Global->partitiontime-
 		   Global->treebuildtime-Global->forcecalctime))/
 	  Global->tracktime);
+
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(cntr3));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(cntr4));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(cntr5));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(cntr6));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(cntr7));
+   printf("MISS_END        = %12lu\n",cntr3);
+   printf("HIT_END         = %12lu\n",cntr4);
+   printf("FLUSH_END       = %12lu\n",cntr5);
+   printf("FLUSH_PULSE_END = %12lu\n",cntr6);
+   printf("AMO_END         = %12lu\n",cntr7);
+   printf("CYCLES_END      = %12lu\n",cntr8);
+
    MAIN_END;
 }
 
@@ -303,7 +332,7 @@ void ANLinit()
 
    Global = (struct GlobalMemory *) G_MALLOC(sizeof(struct GlobalMemory));
    if (Global==NULL) error("No initialization for Global\n");
-    
+
    BARINIT(Global->Barload, NPROC);
    BARINIT(Global->Bartree, NPROC);
    BARINIT(Global->Barcom, NPROC);

--- a/codes/apps/barnes/code.c.in
+++ b/codes/apps/barnes/code.c.in
@@ -252,20 +252,28 @@ int main (int argc, string argv[])
      }
    }
 
-   long unsigned cntr3,cntr4,cntr5,cntr6,cntr7,cntr8;
+   // initialize performance counters
+   long unsigned miss_cntr_start,       miss_cntr_end;
+   long unsigned hit_cntr_start,        hit_cntr_end;
+   long unsigned flush_cntr_start,      flush_cntr_end;
+   long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,        amo_cntr_end;
+   long unsigned cycles_cntr_start,     cycles_cntr_end;
 
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(cntr3));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(cntr4));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(cntr5));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(cntr6));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(cntr7));
-   printf("MISS_START        = %12lu\n",cntr3);
-   printf("HIT_START         = %12lu\n",cntr4);
-   printf("FLUSH_START       = %12lu\n",cntr5);
-   printf("FLUSH_PULSE_START = %12lu\n",cntr6);
-   printf("AMO_START         = %12lu\n",cntr7);
-   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cntr8));
-   printf("CYCLES_START      = %12lu\n",cntr8);
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+
+   printf("MISS_START        = %12lu\n",miss_cntr_start);
+   printf("HIT_START         = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START       = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START         = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+   printf("\n");
 
    Global = NULL;
    initparam(defv);
@@ -289,7 +297,6 @@ int main (int argc, string argv[])
    SPLASH3_ROI_END();
 
    CLOCK(Global->computeend);
-   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cntr8));
 
    printf("COMPUTEEND    = %12lu\n",Global->computeend);
    printf("COMPUTETIME   = %12lu\n",Global->computeend - Global->computestart);
@@ -307,17 +314,29 @@ int main (int argc, string argv[])
 		   Global->treebuildtime-Global->forcecalctime))/
 	  Global->tracktime);
 
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(cntr3));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(cntr4));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(cntr5));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(cntr6));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(cntr7));
-   printf("MISS_END        = %12lu\n",cntr3);
-   printf("HIT_END         = %12lu\n",cntr4);
-   printf("FLUSH_END       = %12lu\n",cntr5);
-   printf("FLUSH_PULSE_END = %12lu\n",cntr6);
-   printf("AMO_END         = %12lu\n",cntr7);
-   printf("CYCLES_END      = %12lu\n",cntr8);
+   // read out performance counters
+   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+
+   printf("MISS_END        = %12lu\n",miss_cntr_end);
+   printf("HIT_END         = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END       = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END         = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+   printf("\n");
+
+   printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("\n");
 
    MAIN_END;
 }

--- a/codes/apps/ocean/contiguous_partitions/main.c.in
+++ b/codes/apps/ocean/contiguous_partitions/main.c.in
@@ -161,28 +161,43 @@ int main(int argc, char *argv[])
 
 
    // initialize performance counters
-   long unsigned miss_cntr_start,       miss_cntr_end;
-   long unsigned hit_cntr_start,        hit_cntr_end;
-   long unsigned flush_cntr_start,      flush_cntr_end;
-   long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
-   long unsigned amo_cntr_start,        amo_cntr_end;
-   long unsigned cycles_cntr_start,     cycles_cntr_end;
+   long unsigned miss_cntr_start,               miss_cntr_end;
+   long unsigned hit_cntr_start,                hit_cntr_end;
+   long unsigned flush_cntr_start,              flush_cntr_end;
+   long unsigned flush_pulse_cntr_start,        flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,                amo_cntr_end;
+   long unsigned cycles_cntr_start,             cycles_cntr_end;
+   long unsigned wr_hit_unique_cntr_start,      wr_hit_unique_cntr_end;
+   long unsigned wr_hit_shared_cntr_start,      wr_hit_shared_cntr_end;
+   long unsigned wr_miss_cntr_start,            wr_miss_cntr_end;
+   long unsigned clean_invalid_hit_cntr_start,  clean_invalid_hit_cntr_end;
+   long unsigned clean_invalid_miss_cntr_start, clean_invalid_miss_cntr_end;
 
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
-   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_start));
 
-   printf("MISS_START        = %12lu\n",miss_cntr_start);
-   printf("HIT_START         = %12lu\n",hit_cntr_start);
-   printf("FLUSH_START       = %12lu\n",flush_cntr_start);
-   printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
-   printf("AMO_START         = %12lu\n",amo_cntr_start);
-   printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+   printf("MISS_START               = %12lu\n",miss_cntr_start);
+   printf("HIT_START                = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START              = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START        = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START                = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START             = %12lu\n",cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE_START   = %12lu\n",wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED_START   = %12lu\n",wr_hit_shared_cntr_start);
+   printf("WRITE_MISS_START         = %12lu\n",wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT_START  = %12lu\n",clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS_START = %12lu\n",clean_invalid_miss_cntr_start);
+
    printf("\n");
-
 
    CLOCK(start)
 
@@ -559,27 +574,43 @@ int main(int argc, char *argv[])
    printf("\n");
 
    // read out performance counters
-   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
-   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_end));
 
-   printf("MISS_END        = %12lu\n",miss_cntr_end);
-   printf("HIT_END         = %12lu\n",hit_cntr_end);
-   printf("FLUSH_END       = %12lu\n",flush_cntr_end);
-   printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
-   printf("AMO_END         = %12lu\n",amo_cntr_end);
-   printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+   printf("\n");
+   printf("MISS_END                 = %12lu\n",miss_cntr_end);
+   printf("HIT_END                  = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END                = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END          = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END                  = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END               = %12lu\n",cycles_cntr_end);
+   printf("WRITE_HIT_UNIQUE_END     = %12lu\n",wr_hit_unique_cntr_end);
+   printf("WRITE_HIT_SHARED_END     = %12lu\n",wr_hit_shared_cntr_end);
+   printf("WRITE_MISS_END           = %12lu\n",wr_miss_cntr_end);
+   printf("CLEAN_INVALID_HIT_END    = %12lu\n",clean_invalid_hit_cntr_end);
+   printf("CLEAN_INVALID_MISS_END   = %12lu\n",clean_invalid_miss_cntr_end);
    printf("\n");
 
-   printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
-   printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
-   printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
-   printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
-   printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
-   printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("MISS COUNT               = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT                = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT              = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT        = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT                = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT             = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE COUNT   = %12lu\n",wr_hit_unique_cntr_end - wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED COUNT   = %12lu\n",wr_hit_shared_cntr_end - wr_hit_shared_cntr_start);
+   printf("WRITE_MISS COUNT         = %12lu\n",wr_miss_cntr_end - wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT COUNT  = %12lu\n",clean_invalid_hit_cntr_end - clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS COUNT = %12lu\n",clean_invalid_miss_cntr_end - clean_invalid_miss_cntr_start);
    printf("\n");
 
    MAIN_END

--- a/codes/apps/ocean/contiguous_partitions/main.c.in
+++ b/codes/apps/ocean/contiguous_partitions/main.c.in
@@ -159,6 +159,31 @@ int main(int argc, char *argv[])
    unsigned long computeend;
    unsigned long start;
 
+
+   // initialize performance counters
+   long unsigned miss_cntr_start,       miss_cntr_end;
+   long unsigned hit_cntr_start,        hit_cntr_end;
+   long unsigned flush_cntr_start,      flush_cntr_end;
+   long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,        amo_cntr_end;
+   long unsigned cycles_cntr_start,     cycles_cntr_end;
+
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+
+   printf("MISS_START        = %12lu\n",miss_cntr_start);
+   printf("HIT_START         = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START       = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START         = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+   printf("\n");
+
+
    CLOCK(start)
 
    while ((ch = getopt(argc, argv, "n:p:e:r:t:soh")) != -1) {
@@ -531,6 +556,30 @@ int main(int argc, char *argv[])
    printf("Total time with initialization    : %16lu\n", computeend-global->starttime);
    printf("Total time without initialization : %16lu\n", computeend-global->trackstart);
    printf("    (excludes first timestep)\n");
+   printf("\n");
+
+   // read out performance counters
+   __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+
+   printf("MISS_END        = %12lu\n",miss_cntr_end);
+   printf("HIT_END         = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END       = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END         = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+   printf("\n");
+
+   printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
    printf("\n");
 
    MAIN_END

--- a/codes/apps/water-nsquared/water.c.in
+++ b/codes/apps/water-nsquared/water.c.in
@@ -112,28 +112,44 @@ int main(int argc, char **argv)
         the WorkStart routine.
         */
 
-    // initialize performance counters
-    long unsigned miss_cntr_start,       miss_cntr_end;
-    long unsigned hit_cntr_start,        hit_cntr_end;
-    long unsigned flush_cntr_start,      flush_cntr_end;
-    long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
-    long unsigned amo_cntr_start,        amo_cntr_end;
-    long unsigned cycles_cntr_start,     cycles_cntr_end;
+   // initialize performance counters
+   long unsigned miss_cntr_start,               miss_cntr_end;
+   long unsigned hit_cntr_start,                hit_cntr_end;
+   long unsigned flush_cntr_start,              flush_cntr_end;
+   long unsigned flush_pulse_cntr_start,        flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,                amo_cntr_end;
+   long unsigned cycles_cntr_start,             cycles_cntr_end;
+   long unsigned wr_hit_unique_cntr_start,      wr_hit_unique_cntr_end;
+   long unsigned wr_hit_shared_cntr_start,      wr_hit_shared_cntr_end;
+   long unsigned wr_miss_cntr_start,            wr_miss_cntr_end;
+   long unsigned clean_invalid_hit_cntr_start,  clean_invalid_hit_cntr_end;
+   long unsigned clean_invalid_miss_cntr_start, clean_invalid_miss_cntr_end;
 
-    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_start));
 
-    printf("MISS_START        = %12lu\n",miss_cntr_start);
-    printf("HIT_START         = %12lu\n",hit_cntr_start);
-    printf("FLUSH_START       = %12lu\n",flush_cntr_start);
-    printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
-    printf("AMO_START         = %12lu\n",amo_cntr_start);
-    printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
-    printf("\n");
+   printf("MISS_START               = %12lu\n",miss_cntr_start);
+   printf("HIT_START                = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START              = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START        = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START                = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START             = %12lu\n",cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE_START   = %12lu\n",wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED_START   = %12lu\n",wr_hit_shared_cntr_start);
+   printf("WRITE_MISS_START         = %12lu\n",wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT_START  = %12lu\n",clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS_START = %12lu\n",clean_invalid_miss_cntr_start);
+
+   printf("\n");
 
     six = stdout;   /* output file */
 
@@ -287,29 +303,45 @@ int main(int argc, char **argv)
     printf("Intermolecular time only (2nd timestep onward) = %lu\n",gl->intertime);
     printf("Other time (2nd timestep onward) = %lu\n",gl->tracktime - gl->intratime - gl->intertime);
 
-    // read out performance counters
-    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+   // read out performance counters
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_end));
 
-    printf("MISS_END        = %12lu\n",miss_cntr_end);
-    printf("HIT_END         = %12lu\n",hit_cntr_end);
-    printf("FLUSH_END       = %12lu\n",flush_cntr_end);
-    printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
-    printf("AMO_END         = %12lu\n",amo_cntr_end);
-    printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
-    printf("\n");
+   printf("\n");
+   printf("MISS_END                 = %12lu\n",miss_cntr_end);
+   printf("HIT_END                  = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END                = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END          = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END                  = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END               = %12lu\n",cycles_cntr_end);
+   printf("WRITE_HIT_UNIQUE_END     = %12lu\n",wr_hit_unique_cntr_end);
+   printf("WRITE_HIT_SHARED_END     = %12lu\n",wr_hit_shared_cntr_end);
+   printf("WRITE_MISS_END           = %12lu\n",wr_miss_cntr_end);
+   printf("CLEAN_INVALID_HIT_END    = %12lu\n",clean_invalid_hit_cntr_end);
+   printf("CLEAN_INVALID_MISS_END   = %12lu\n",clean_invalid_miss_cntr_end);
+   printf("\n");
 
-    printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
-    printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
-    printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
-    printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
-    printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
-    printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
-    printf("\n");
+   printf("MISS COUNT               = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT                = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT              = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT        = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT                = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT             = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE COUNT   = %12lu\n",wr_hit_unique_cntr_end - wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED COUNT   = %12lu\n",wr_hit_shared_cntr_end - wr_hit_shared_cntr_start);
+   printf("WRITE_MISS COUNT         = %12lu\n",wr_miss_cntr_end - wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT COUNT  = %12lu\n",clean_invalid_hit_cntr_end - clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS COUNT = %12lu\n",clean_invalid_miss_cntr_end - clean_invalid_miss_cntr_start);
+   printf("\n");
 
     printf("\nExited Happily with XTT = %g (note: XTT value is garbage if NPRINT > NSTEP)\n", XTT);
 

--- a/codes/apps/water-nsquared/water.c.in
+++ b/codes/apps/water-nsquared/water.c.in
@@ -112,6 +112,29 @@ int main(int argc, char **argv)
         the WorkStart routine.
         */
 
+    // initialize performance counters
+    long unsigned miss_cntr_start,       miss_cntr_end;
+    long unsigned hit_cntr_start,        hit_cntr_end;
+    long unsigned flush_cntr_start,      flush_cntr_end;
+    long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
+    long unsigned amo_cntr_start,        amo_cntr_end;
+    long unsigned cycles_cntr_start,     cycles_cntr_end;
+
+    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+
+    printf("MISS_START        = %12lu\n",miss_cntr_start);
+    printf("HIT_START         = %12lu\n",hit_cntr_start);
+    printf("FLUSH_START       = %12lu\n",flush_cntr_start);
+    printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
+    printf("AMO_START         = %12lu\n",amo_cntr_start);
+    printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+    printf("\n");
+
     six = stdout;   /* output file */
 
     TEMP  =298.0;
@@ -263,6 +286,30 @@ int main(int argc, char **argv)
     printf("Intramolecular time only (2nd timestep onward) = %lu\n",gl->intratime);
     printf("Intermolecular time only (2nd timestep onward) = %lu\n",gl->intertime);
     printf("Other time (2nd timestep onward) = %lu\n",gl->tracktime - gl->intratime - gl->intertime);
+
+    // read out performance counters
+    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+
+    printf("MISS_END        = %12lu\n",miss_cntr_end);
+    printf("HIT_END         = %12lu\n",hit_cntr_end);
+    printf("FLUSH_END       = %12lu\n",flush_cntr_end);
+    printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
+    printf("AMO_END         = %12lu\n",amo_cntr_end);
+    printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+    printf("\n");
+
+    printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
+    printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
+    printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
+    printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+    printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
+    printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+    printf("\n");
 
     printf("\nExited Happily with XTT = %g (note: XTT value is garbage if NPRINT > NSTEP)\n", XTT);
 

--- a/codes/apps/water-spatial/water.c.in
+++ b/codes/apps/water-spatial/water.c.in
@@ -119,28 +119,43 @@ int main(int argc, char **argv)
 
 
 
-    // initialize performance counters
-    long unsigned miss_cntr_start,       miss_cntr_end;
-    long unsigned hit_cntr_start,        hit_cntr_end;
-    long unsigned flush_cntr_start,      flush_cntr_end;
-    long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
-    long unsigned amo_cntr_start,        amo_cntr_end;
-    long unsigned cycles_cntr_start,     cycles_cntr_end;
+   // initialize performance counters
+   long unsigned miss_cntr_start,               miss_cntr_end;
+   long unsigned hit_cntr_start,                hit_cntr_end;
+   long unsigned flush_cntr_start,              flush_cntr_end;
+   long unsigned flush_pulse_cntr_start,        flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,                amo_cntr_end;
+   long unsigned cycles_cntr_start,             cycles_cntr_end;
+   long unsigned wr_hit_unique_cntr_start,      wr_hit_unique_cntr_end;
+   long unsigned wr_hit_shared_cntr_start,      wr_hit_shared_cntr_end;
+   long unsigned wr_miss_cntr_start,            wr_miss_cntr_end;
+   long unsigned clean_invalid_hit_cntr_start,  clean_invalid_hit_cntr_end;
+   long unsigned clean_invalid_miss_cntr_start, clean_invalid_miss_cntr_end;
 
-    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
-    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_start));
 
-    printf("MISS_START        = %12lu\n",miss_cntr_start);
-    printf("HIT_START         = %12lu\n",hit_cntr_start);
-    printf("FLUSH_START       = %12lu\n",flush_cntr_start);
-    printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
-    printf("AMO_START         = %12lu\n",amo_cntr_start);
-    printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
-    printf("\n");
+   printf("MISS_START               = %12lu\n",miss_cntr_start);
+   printf("HIT_START                = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START              = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START        = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START                = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START             = %12lu\n",cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE_START   = %12lu\n",wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED_START   = %12lu\n",wr_hit_shared_cntr_start);
+   printf("WRITE_MISS_START         = %12lu\n",wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT_START  = %12lu\n",clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS_START = %12lu\n",clean_invalid_miss_cntr_start);
+   printf("\n");
 
     six = stdout;
 
@@ -380,30 +395,45 @@ int main(int argc, char **argv)
     printf("Intermolecular time only (2nd timestep onward) = %lu\n",gl->intertime);
     printf("Other time (2nd timestep onward) = %lu\n",gl->tracktime - gl->intratime - gl->intertime);
 
-    // read out performance counters
-    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
-    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+   // read out performance counters
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_end));
 
-    printf("\n");
-    printf("MISS_END        = %12lu\n",miss_cntr_end);
-    printf("HIT_END         = %12lu\n",hit_cntr_end);
-    printf("FLUSH_END       = %12lu\n",flush_cntr_end);
-    printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
-    printf("AMO_END         = %12lu\n",amo_cntr_end);
-    printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
-    printf("\n");
+   printf("\n");
+   printf("MISS_END                 = %12lu\n",miss_cntr_end);
+   printf("HIT_END                  = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END                = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END          = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END                  = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END               = %12lu\n",cycles_cntr_end);
+   printf("WRITE_HIT_UNIQUE_END     = %12lu\n",wr_hit_unique_cntr_end);
+   printf("WRITE_HIT_SHARED_END     = %12lu\n",wr_hit_shared_cntr_end);
+   printf("WRITE_MISS_END           = %12lu\n",wr_miss_cntr_end);
+   printf("CLEAN_INVALID_HIT_END    = %12lu\n",clean_invalid_hit_cntr_end);
+   printf("CLEAN_INVALID_MISS_END   = %12lu\n",clean_invalid_miss_cntr_end);
+   printf("\n");
 
-    printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
-    printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
-    printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
-    printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
-    printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
-    printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
-    printf("\n");
+   printf("MISS COUNT               = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT                = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT              = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT        = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT                = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT             = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE COUNT   = %12lu\n",wr_hit_unique_cntr_end - wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED COUNT   = %12lu\n",wr_hit_shared_cntr_end - wr_hit_shared_cntr_start);
+   printf("WRITE_MISS COUNT         = %12lu\n",wr_miss_cntr_end - wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT COUNT  = %12lu\n",clean_invalid_hit_cntr_end - clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS COUNT = %12lu\n",clean_invalid_miss_cntr_end - clean_invalid_miss_cntr_start);
+   printf("\n");
 
     printf("\nExited Happily with XTT = %g (note: XTT value is garbage if NPRINT > NSTEP)\n", XTT);
 

--- a/codes/apps/water-spatial/water.c.in
+++ b/codes/apps/water-spatial/water.c.in
@@ -117,6 +117,31 @@ int main(int argc, char **argv)
             here, even before the other (child) processes are bound later in mdmain().
             */
 
+
+
+    // initialize performance counters
+    long unsigned miss_cntr_start,       miss_cntr_end;
+    long unsigned hit_cntr_start,        hit_cntr_end;
+    long unsigned flush_cntr_start,      flush_cntr_end;
+    long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
+    long unsigned amo_cntr_start,        amo_cntr_end;
+    long unsigned cycles_cntr_start,     cycles_cntr_end;
+
+    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+
+    printf("MISS_START        = %12lu\n",miss_cntr_start);
+    printf("HIT_START         = %12lu\n",hit_cntr_start);
+    printf("FLUSH_START       = %12lu\n",flush_cntr_start);
+    printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
+    printf("AMO_START         = %12lu\n",amo_cntr_start);
+    printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+    printf("\n");
+
     six = stdout;
 
     TEMP  =298.0;
@@ -354,6 +379,31 @@ int main(int argc, char **argv)
     printf("Intramolecular time only (2nd timestep onward) = %lu\n",gl->intratime);
     printf("Intermolecular time only (2nd timestep onward) = %lu\n",gl->intertime);
     printf("Other time (2nd timestep onward) = %lu\n",gl->tracktime - gl->intratime - gl->intertime);
+
+    // read out performance counters
+    __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
+    __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+
+    printf("\n");
+    printf("MISS_END        = %12lu\n",miss_cntr_end);
+    printf("HIT_END         = %12lu\n",hit_cntr_end);
+    printf("FLUSH_END       = %12lu\n",flush_cntr_end);
+    printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
+    printf("AMO_END         = %12lu\n",amo_cntr_end);
+    printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+    printf("\n");
+
+    printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
+    printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
+    printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
+    printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+    printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
+    printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+    printf("\n");
 
     printf("\nExited Happily with XTT = %g (note: XTT value is garbage if NPRINT > NSTEP)\n", XTT);
 

--- a/codes/kernels/lu/contiguous_blocks/lu.c.in
+++ b/codes/kernels/lu/contiguous_blocks/lu.c.in
@@ -119,28 +119,44 @@ int main(int argc, char *argv[])
   long size;
   unsigned long start;
 
-  // initialize performance counters
-  long unsigned miss_cntr_start,       miss_cntr_end;
-  long unsigned hit_cntr_start,        hit_cntr_end;
-  long unsigned flush_cntr_start,      flush_cntr_end;
-  long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
-  long unsigned amo_cntr_start,        amo_cntr_end;
-  long unsigned cycles_cntr_start,     cycles_cntr_end;
+   // initialize performance counters
+   long unsigned miss_cntr_start,               miss_cntr_end;
+   long unsigned hit_cntr_start,                hit_cntr_end;
+   long unsigned flush_cntr_start,              flush_cntr_end;
+   long unsigned flush_pulse_cntr_start,        flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,                amo_cntr_end;
+   long unsigned cycles_cntr_start,             cycles_cntr_end;
+   long unsigned wr_hit_unique_cntr_start,      wr_hit_unique_cntr_end;
+   long unsigned wr_hit_shared_cntr_start,      wr_hit_shared_cntr_end;
+   long unsigned wr_miss_cntr_start,            wr_miss_cntr_end;
+   long unsigned clean_invalid_hit_cntr_start,  clean_invalid_hit_cntr_end;
+   long unsigned clean_invalid_miss_cntr_start, clean_invalid_miss_cntr_end;
 
-  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_start));
 
-  printf("MISS_START        = %12lu\n",miss_cntr_start);
-  printf("HIT_START         = %12lu\n",hit_cntr_start);
-  printf("FLUSH_START       = %12lu\n",flush_cntr_start);
-  printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
-  printf("AMO_START         = %12lu\n",amo_cntr_start);
-  printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
-  printf("\n");
+   printf("MISS_START               = %12lu\n",miss_cntr_start);
+   printf("HIT_START                = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START              = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START        = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START                = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START             = %12lu\n",cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE_START   = %12lu\n",wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED_START   = %12lu\n",wr_hit_shared_cntr_start);
+   printf("WRITE_MISS_START         = %12lu\n",wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT_START  = %12lu\n",clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS_START = %12lu\n",clean_invalid_miss_cntr_start);
+   printf("\n");
+
 
   CLOCK(start)
 
@@ -420,29 +436,45 @@ int main(int argc, char *argv[])
   printf("Total time without initialization : %16lu\n", Global->rf-Global->rs);
   printf("\n");
 
-  // read out performance counters
-  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+   // read out performance counters
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_end));
 
-  printf("MISS_END        = %12lu\n",miss_cntr_end);
-  printf("HIT_END         = %12lu\n",hit_cntr_end);
-  printf("FLUSH_END       = %12lu\n",flush_cntr_end);
-  printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
-  printf("AMO_END         = %12lu\n",amo_cntr_end);
-  printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
-  printf("\n");
+   printf("\n");
+   printf("MISS_END                 = %12lu\n",miss_cntr_end);
+   printf("HIT_END                  = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END                = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END          = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END                  = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END               = %12lu\n",cycles_cntr_end);
+   printf("WRITE_HIT_UNIQUE_END     = %12lu\n",wr_hit_unique_cntr_end);
+   printf("WRITE_HIT_SHARED_END     = %12lu\n",wr_hit_shared_cntr_end);
+   printf("WRITE_MISS_END           = %12lu\n",wr_miss_cntr_end);
+   printf("CLEAN_INVALID_HIT_END    = %12lu\n",clean_invalid_hit_cntr_end);
+   printf("CLEAN_INVALID_MISS_END   = %12lu\n",clean_invalid_miss_cntr_end);
+   printf("\n");
 
-  printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
-  printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
-  printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
-  printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
-  printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
-  printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
-  printf("\n");
+   printf("MISS COUNT               = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT                = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT              = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT        = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT                = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT             = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE COUNT   = %12lu\n",wr_hit_unique_cntr_end - wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED COUNT   = %12lu\n",wr_hit_shared_cntr_end - wr_hit_shared_cntr_start);
+   printf("WRITE_MISS COUNT         = %12lu\n",wr_miss_cntr_end - wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT COUNT  = %12lu\n",clean_invalid_hit_cntr_end - clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS COUNT = %12lu\n",clean_invalid_miss_cntr_end - clean_invalid_miss_cntr_start);
+   printf("\n");
 
   if (test_result) {
     printf("                             TESTING RESULTS\n");

--- a/codes/kernels/lu/contiguous_blocks/lu.c.in
+++ b/codes/kernels/lu/contiguous_blocks/lu.c.in
@@ -119,6 +119,29 @@ int main(int argc, char *argv[])
   long size;
   unsigned long start;
 
+  // initialize performance counters
+  long unsigned miss_cntr_start,       miss_cntr_end;
+  long unsigned hit_cntr_start,        hit_cntr_end;
+  long unsigned flush_cntr_start,      flush_cntr_end;
+  long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
+  long unsigned amo_cntr_start,        amo_cntr_end;
+  long unsigned cycles_cntr_start,     cycles_cntr_end;
+
+  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+
+  printf("MISS_START        = %12lu\n",miss_cntr_start);
+  printf("HIT_START         = %12lu\n",hit_cntr_start);
+  printf("FLUSH_START       = %12lu\n",flush_cntr_start);
+  printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
+  printf("AMO_START         = %12lu\n",amo_cntr_start);
+  printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+  printf("\n");
+
   CLOCK(start)
 
   while ((ch = getopt(argc, argv, "n:p:b:cstoh")) != -1) {
@@ -395,6 +418,30 @@ int main(int argc, char *argv[])
   printf("Overall finish time               : %16lu\n", Global->rf);
   printf("Total time with initialization    : %16lu\n", Global->rf-Global->starttime);
   printf("Total time without initialization : %16lu\n", Global->rf-Global->rs);
+  printf("\n");
+
+  // read out performance counters
+  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+
+  printf("MISS_END        = %12lu\n",miss_cntr_end);
+  printf("HIT_END         = %12lu\n",hit_cntr_end);
+  printf("FLUSH_END       = %12lu\n",flush_cntr_end);
+  printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
+  printf("AMO_END         = %12lu\n",amo_cntr_end);
+  printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+  printf("\n");
+
+  printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
+  printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
+  printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
+  printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+  printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
+  printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
   printf("\n");
 
   if (test_result) {

--- a/codes/kernels/lu/non_contiguous_blocks/lu.c.in
+++ b/codes/kernels/lu/non_contiguous_blocks/lu.c.in
@@ -111,6 +111,29 @@ int main(int argc, char *argv[])
   double avg_fac, avg_solve, avg_mod, avg_bar;
   unsigned long start;
 
+  // initialize performance counters
+  long unsigned miss_cntr_start,       miss_cntr_end;
+  long unsigned hit_cntr_start,        hit_cntr_end;
+  long unsigned flush_cntr_start,      flush_cntr_end;
+  long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
+  long unsigned amo_cntr_start,        amo_cntr_end;
+  long unsigned cycles_cntr_start,     cycles_cntr_end;
+
+  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
+  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+
+  printf("MISS_START        = %12lu\n",miss_cntr_start);
+  printf("HIT_START         = %12lu\n",hit_cntr_start);
+  printf("FLUSH_START       = %12lu\n",flush_cntr_start);
+  printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
+  printf("AMO_START         = %12lu\n",amo_cntr_start);
+  printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
+  printf("\n");
+
   CLOCK(start);
 
   while ((ch = getopt(argc, argv, "n:p:b:cstoh")) != -1) {
@@ -307,6 +330,30 @@ int main(int argc, char *argv[])
   printf("Overall finish time               : %16lu\n", Global->rf);
   printf("Total time with initialization    : %16lu\n", Global->rf-Global->starttime);
   printf("Total time without initialization : %16lu\n", Global->rf-Global->rs);
+  printf("\n");
+
+  // read out performance counters
+  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
+  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+
+  printf("MISS_END        = %12lu\n",miss_cntr_end);
+  printf("HIT_END         = %12lu\n",hit_cntr_end);
+  printf("FLUSH_END       = %12lu\n",flush_cntr_end);
+  printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
+  printf("AMO_END         = %12lu\n",amo_cntr_end);
+  printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
+  printf("\n");
+
+  printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
+  printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
+  printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
+  printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+  printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
+  printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
   printf("\n");
 
   if (test_result) {

--- a/codes/kernels/lu/non_contiguous_blocks/lu.c.in
+++ b/codes/kernels/lu/non_contiguous_blocks/lu.c.in
@@ -111,29 +111,43 @@ int main(int argc, char *argv[])
   double avg_fac, avg_solve, avg_mod, avg_bar;
   unsigned long start;
 
-  // initialize performance counters
-  long unsigned miss_cntr_start,       miss_cntr_end;
-  long unsigned hit_cntr_start,        hit_cntr_end;
-  long unsigned flush_cntr_start,      flush_cntr_end;
-  long unsigned flush_pulse_cntr_start, flush_pulse_cntr_end;
-  long unsigned amo_cntr_start,        amo_cntr_end;
-  long unsigned cycles_cntr_start,     cycles_cntr_end;
+   // initialize performance counters
+   long unsigned miss_cntr_start,               miss_cntr_end;
+   long unsigned hit_cntr_start,                hit_cntr_end;
+   long unsigned flush_cntr_start,              flush_cntr_end;
+   long unsigned flush_pulse_cntr_start,        flush_pulse_cntr_end;
+   long unsigned amo_cntr_start,                amo_cntr_end;
+   long unsigned cycles_cntr_start,             cycles_cntr_end;
+   long unsigned wr_hit_unique_cntr_start,      wr_hit_unique_cntr_end;
+   long unsigned wr_hit_shared_cntr_start,      wr_hit_shared_cntr_end;
+   long unsigned wr_miss_cntr_start,            wr_miss_cntr_end;
+   long unsigned clean_invalid_hit_cntr_start,  clean_invalid_hit_cntr_end;
+   long unsigned clean_invalid_miss_cntr_start, clean_invalid_miss_cntr_end;
 
-  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_start));
-  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_start));
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_start));
 
-  printf("MISS_START        = %12lu\n",miss_cntr_start);
-  printf("HIT_START         = %12lu\n",hit_cntr_start);
-  printf("FLUSH_START       = %12lu\n",flush_cntr_start);
-  printf("FLUSH_PULSE_START = %12lu\n",flush_pulse_cntr_start);
-  printf("AMO_START         = %12lu\n",amo_cntr_start);
-  printf("CYCLES_START      = %12lu\n",cycles_cntr_start);
-  printf("\n");
-
+   printf("MISS_START               = %12lu\n",miss_cntr_start);
+   printf("HIT_START                = %12lu\n",hit_cntr_start);
+   printf("FLUSH_START              = %12lu\n",flush_cntr_start);
+   printf("FLUSH_PULSE_START        = %12lu\n",flush_pulse_cntr_start);
+   printf("AMO_START                = %12lu\n",amo_cntr_start);
+   printf("CYCLES_START             = %12lu\n",cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE_START   = %12lu\n",wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED_START   = %12lu\n",wr_hit_shared_cntr_start);
+   printf("WRITE_MISS_START         = %12lu\n",wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT_START  = %12lu\n",clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS_START = %12lu\n",clean_invalid_miss_cntr_start);
+   printf("\n");
   CLOCK(start);
 
   while ((ch = getopt(argc, argv, "n:p:b:cstoh")) != -1) {
@@ -332,29 +346,45 @@ int main(int argc, char *argv[])
   printf("Total time without initialization : %16lu\n", Global->rf-Global->rs);
   printf("\n");
 
-  // read out performance counters
-  __asm__ volatile ("csrr %0, hpmcounter8" : "=r"(cycles_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter3" : "=r"(miss_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter4" : "=r"(hit_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter5" : "=r"(flush_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter6" : "=r"(flush_pulse_cntr_end));
-  __asm__ volatile ("csrr %0, hpmcounter7" : "=r"(amo_cntr_end));
+   // read out performance counters
+   __asm__ volatile ("csrr %0, hpmcounter8"  : "=r"(cycles_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter3"  : "=r"(miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter4"  : "=r"(hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter5"  : "=r"(flush_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter6"  : "=r"(flush_pulse_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter7"  : "=r"(amo_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter9"  : "=r"(wr_hit_unique_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter10" : "=r"(wr_hit_shared_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter11" : "=r"(wr_miss_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter12" : "=r"(clean_invalid_hit_cntr_end));
+   __asm__ volatile ("csrr %0, hpmcounter13" : "=r"(clean_invalid_miss_cntr_end));
 
-  printf("MISS_END        = %12lu\n",miss_cntr_end);
-  printf("HIT_END         = %12lu\n",hit_cntr_end);
-  printf("FLUSH_END       = %12lu\n",flush_cntr_end);
-  printf("FLUSH_PULSE_END = %12lu\n",flush_pulse_cntr_end);
-  printf("AMO_END         = %12lu\n",amo_cntr_end);
-  printf("CYCLES_END      = %12lu\n",cycles_cntr_end);
-  printf("\n");
+   printf("\n");
+   printf("MISS_END                 = %12lu\n",miss_cntr_end);
+   printf("HIT_END                  = %12lu\n",hit_cntr_end);
+   printf("FLUSH_END                = %12lu\n",flush_cntr_end);
+   printf("FLUSH_PULSE_END          = %12lu\n",flush_pulse_cntr_end);
+   printf("AMO_END                  = %12lu\n",amo_cntr_end);
+   printf("CYCLES_END               = %12lu\n",cycles_cntr_end);
+   printf("WRITE_HIT_UNIQUE_END     = %12lu\n",wr_hit_unique_cntr_end);
+   printf("WRITE_HIT_SHARED_END     = %12lu\n",wr_hit_shared_cntr_end);
+   printf("WRITE_MISS_END           = %12lu\n",wr_miss_cntr_end);
+   printf("CLEAN_INVALID_HIT_END    = %12lu\n",clean_invalid_hit_cntr_end);
+   printf("CLEAN_INVALID_MISS_END   = %12lu\n",clean_invalid_miss_cntr_end);
+   printf("\n");
 
-  printf("MISS COUNT        = %12lu\n",miss_cntr_end - miss_cntr_start);
-  printf("HIT COUNT         = %12lu\n",hit_cntr_end - hit_cntr_start);
-  printf("FLUSH COUNT       = %12lu\n",flush_cntr_end - flush_cntr_start);
-  printf("FLUSH_PULSE COUNT = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
-  printf("AMO COUNT         = %12lu\n",amo_cntr_end - amo_cntr_start);
-  printf("CYCLES COUNT      = %12lu\n",cycles_cntr_end - cycles_cntr_start);
-  printf("\n");
+   printf("MISS COUNT               = %12lu\n",miss_cntr_end - miss_cntr_start);
+   printf("HIT COUNT                = %12lu\n",hit_cntr_end - hit_cntr_start);
+   printf("FLUSH COUNT              = %12lu\n",flush_cntr_end - flush_cntr_start);
+   printf("FLUSH_PULSE COUNT        = %12lu\n",flush_pulse_cntr_end - flush_pulse_cntr_start);
+   printf("AMO COUNT                = %12lu\n",amo_cntr_end - amo_cntr_start);
+   printf("CYCLES COUNT             = %12lu\n",cycles_cntr_end - cycles_cntr_start);
+   printf("WRITE_HIT_UNIQUE COUNT   = %12lu\n",wr_hit_unique_cntr_end - wr_hit_unique_cntr_start);
+   printf("WRITE_HIT_SHARED COUNT   = %12lu\n",wr_hit_shared_cntr_end - wr_hit_shared_cntr_start);
+   printf("WRITE_MISS COUNT         = %12lu\n",wr_miss_cntr_end - wr_miss_cntr_start);
+   printf("CLEAN_INVALID_HIT COUNT  = %12lu\n",clean_invalid_hit_cntr_end - clean_invalid_hit_cntr_start);
+   printf("CLEAN_INVALID_MISS COUNT = %12lu\n",clean_invalid_miss_cntr_end - clean_invalid_miss_cntr_start);
+   printf("\n");
 
   if (test_result) {
     printf("                             TESTING RESULTS\n");


### PR DESCRIPTION
- Read out perfromance counters at start and end of (some) tests + caclucate diff.
- Update the Makefile to create the runtest script
- Create minimal splash3 folder to use in boot image